### PR TITLE
Fix critical purchase-flow bugs found in bug hunt

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,4 @@
 # define your env variables for the test env here
-KERNEL_CLASS='App\Kernel'
+KERNEL_CLASS='PhpYabs\Kernel'
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ behat: vendor/autoload.php
 
 .PHONY: phpstan
 phpstan: vendor/autoload.php
-	docker compose exec php vendor/bin/phpstan analyze -v
+	docker compose exec php vendor/bin/phpstan analyze -v --memory-limit=512M
 
 .PHONY: rector
 rector: vendor/autoload.php

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,3 +23,9 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+
+when@test:
+    services:
+        # keep the default framework logger from polluting test output
+        logger:
+            class: Psr\Log\NullLogger

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -27,7 +27,7 @@
         </include>
     </source>
     <php>
-        <env name="APP_ENV" value="test" />
-        <env name="KERNEL_CLASS" value="PhpYabs\Kernel" />
+        <env name="APP_ENV" value="test" force="true" />
+        <env name="KERNEL_CLASS" value="PhpYabs\Kernel" force="true" />
     </php>
 </phpunit>

--- a/src/Controller/PurchaseController.php
+++ b/src/Controller/PurchaseController.php
@@ -55,15 +55,20 @@ class PurchaseController extends AbstractController
             $this->hitRepository,
         );
 
+        $isExplicitId = (bool) preg_match('/^\\d+$/', $id);
+
         if ('current' === $id && $session->has('purchase_id')) {
             $acquisto->setId($session->get('purchase_id'));
-        } elseif (preg_match('/^\\d+$/', $id)) {
+        } elseif ($isExplicitId) {
             if (!$acquisto->setId((int) $id)) {
                 $errmsg = "L'acquisto $id non esiste!";
             }
         }
 
-        $session->set('purchase_id', $acquisto->getId());
+        // viewing an explicit purchase must not turn it into the session's current cart
+        if (!$isExplicitId) {
+            $session->set('purchase_id', $acquisto->getId());
+        }
 
         $trovato = true;
 

--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpYabs\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Money\Money;
@@ -53,6 +54,11 @@ class Book
      */
     #[ORM\OneToMany(targetEntity: Destination::class, mappedBy: 'book', cascade: ['persist', 'remove'])]
     private Collection $destinations;
+
+    public function __construct()
+    {
+        $this->destinations = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {

--- a/src/Entity/Purchase.php
+++ b/src/Entity/Purchase.php
@@ -55,7 +55,7 @@ class Purchase
     public function addBook(Book $book): self
     {
         $line = $this->lines->findFirst(
-            fn (PurchaseLine $line) => $line->getBook()->getId() === $book->getId(),
+            fn ($id, PurchaseLine $line) => $line->getBook()->getId() === $book->getId(),
         );
 
         if (!$line) {

--- a/src/Entity/Purchase.php
+++ b/src/Entity/Purchase.php
@@ -55,7 +55,7 @@ class Purchase
     public function addBook(Book $book): self
     {
         $line = $this->lines->findFirst(
-            fn ($id, PurchaseLine $line) => $line->getBook()->getId() === $book->getId(),
+            fn ($key, PurchaseLine $line) => $line->getBook()->getId() === $book->getId(),
         );
 
         if (!$line) {
@@ -71,7 +71,7 @@ class Purchase
     public function removeBook(Book $book): self
     {
         $line = $this->lines->findFirst(
-            fn ($id, PurchaseLine $line) => $line->getBook()->getId() === $book->getId(),
+            fn ($key, PurchaseLine $line) => $line->getBook()->getId() === $book->getId(),
         );
 
         if ($line) {

--- a/src/Service/PurchaseService.php
+++ b/src/Service/PurchaseService.php
@@ -13,6 +13,7 @@ use PhpYabs\Entity\Purchase;
 use PhpYabs\Repository\BookRepository;
 use PhpYabs\Repository\HitRepository;
 use PhpYabs\Repository\PurchaseRepository;
+use PhpYabs\ValueObject\ISBN;
 
 class PurchaseService
 {
@@ -59,10 +60,19 @@ class PurchaseService
 
     public function addBook(string $ISBN): bool
     {
-        $book = $this->bookRepository->findOneBy(['isbn' => $ISBN]);
-        $hit = $this->hitRepository->findOneBy(['isbn' => $ISBN]);
+        try {
+            $isbn = ISBN::fromString($ISBN);
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+
+        $book = $this->bookRepository->findOneBy(['isbn' => (string) $isbn->version13]);
+
+        // the hits table is keyed on the 9-digit ISBN core (CHAR(9) column)
+        $hitKey = $isbn->version10->withoutChecksum;
+        $hit = $this->hitRepository->findOneBy(['isbn' => $hitKey]);
         if (!$hit) {
-            $hit = new Hit()->setIsbn($ISBN);
+            $hit = new Hit()->setIsbn($hitKey);
             $this->em->persist($hit);
         }
 
@@ -109,7 +119,7 @@ class PurchaseService
                     title: $book->getTitle(),
                     author: $book->getAuthor(),
                     publisher: $book->getPublisher(),
-                    price: $book->getPriceObject(),
+                    price: $book->getPrice(),
                     fullISBN: $book->getFullIsbn(),
                     ISBN: $book->getIsbnWithoutChecksum(),
                     rate: $book->getRate()->value,

--- a/src/Service/PurchaseService.php
+++ b/src/Service/PurchaseService.php
@@ -66,10 +66,12 @@ class PurchaseService
             return false;
         }
 
-        $book = $this->bookRepository->findOneBy(['isbn' => (string) $isbn->version13]);
+        $isbn13 = (string) $isbn->version13;
+        $book = $this->bookRepository->findOneBy(['isbn' => $isbn13]);
 
-        // the hits table is keyed on the 9-digit ISBN core (CHAR(9) column)
-        $hitKey = $isbn->version10->withoutChecksum;
+        // the hits table is keyed on the 9-digit ISBN core (CHAR(9) column);
+        // derive it from the ISBN-13 to avoid the lossy 13-to-10 conversion
+        $hitKey = substr($isbn13, 3, 9);
         $hit = $this->hitRepository->findOneBy(['isbn' => $hitKey]);
         if (!$hit) {
             $hit = new Hit()->setIsbn($hitKey);

--- a/src/ValueObject/ISBN.php
+++ b/src/ValueObject/ISBN.php
@@ -38,11 +38,11 @@ abstract class ISBN implements \Stringable
         throw new \InvalidArgumentException('Invalid ISBN provided');
     }
 
-    public abstract ISBN10 $version10 {
+    abstract public ISBN10 $version10 {
         get;
     }
 
-    public abstract ISBN13 $version13 {
+    abstract public ISBN13 $version13 {
         get;
     }
 

--- a/templates/books/tabdel.html.twig
+++ b/templates/books/tabdel.html.twig
@@ -18,7 +18,7 @@
         </tr>
         <tr>
             <th>{{ 'book.fields.price'|trans }}:</th>
-            <td>{{ book.price }}</td>
+            <td>{{ book.price | money_format }}</td>
         </tr>
         <tr>
             <th>{{ 'book.fields.rating'|trans }}:</th>

--- a/tests/Entity/PurchaseTest.php
+++ b/tests/Entity/PurchaseTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpYabs\Tests\Entity;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use PhpYabs\Entity\Book;
+use PhpYabs\Entity\Purchase;
+
+#[CoversClass(Purchase::class)]
+class PurchaseTest extends TestCase
+{
+    public function testAddBookToEmptyPurchase(): void
+    {
+        $purchase = new Purchase();
+        $purchase->addBook($this->makeBook(1));
+
+        $this->assertCount(1, $purchase->getLines());
+    }
+
+    public function testAddSecondBookCreatesSecondLine(): void
+    {
+        $purchase = new Purchase();
+        $purchase->addBook($this->makeBook(1));
+        $purchase->addBook($this->makeBook(2));
+
+        $this->assertCount(2, $purchase->getLines());
+    }
+
+    public function testAddSameBookTwiceKeepsSingleLine(): void
+    {
+        $book = $this->makeBook(1);
+
+        $purchase = new Purchase();
+        $purchase->addBook($book);
+        $purchase->addBook($book);
+
+        $this->assertCount(1, $purchase->getLines());
+    }
+
+    public function testRemoveBook(): void
+    {
+        $bookToRemove = $this->makeBook(1);
+
+        $purchase = new Purchase();
+        $purchase->addBook($bookToRemove);
+        $purchase->addBook($this->makeBook(2));
+        $purchase->removeBook($bookToRemove);
+
+        $this->assertCount(1, $purchase->getLines());
+    }
+
+    private function makeBook(int $id): Book
+    {
+        return new Book()
+            ->setId($id)
+            ->setIsbn('123456789')
+            ->setTitle('Test Book')
+            ->setAuthor('Test Author')
+            ->setPublisher('Test Publisher')
+        ;
+    }
+}

--- a/tests/Integration/Controller/BookControllerTest.php
+++ b/tests/Integration/Controller/BookControllerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpYabs\Tests\Integration\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Money\Money;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PhpYabs\Controller\BookController;
+use PhpYabs\Entity\Book;
+use PhpYabs\Repository\BookRepository;
+use PhpYabs\ValueObject\ISBN;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+#[CoversClass(BookController::class)]
+class BookControllerTest extends WebTestCase
+{
+    public function testDeleteConfirmationPageRendersBookDetails(): void
+    {
+        $client = static::createClient();
+
+        $isbn = $this->bakeBook('316148410');
+
+        $client->request('GET', "/books/$isbn/delete");
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('.book-delete', 'Test Book');
+    }
+
+    private function bakeBook(string $isbn): string
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $bookRepository = static::getContainer()->get(BookRepository::class);
+
+        $stored = (string) ISBN::fromString($isbn)->version13;
+
+        if (!$bookRepository->findOneBy(['isbn' => $stored])) {
+            $book = new Book()
+                ->setIsbn($isbn)
+                ->setTitle('Test Book')
+                ->setAuthor('Test Author')
+                ->setPublisher('Test Publisher')
+                ->setPrice(Money::EUR(1000))
+            ;
+            $entityManager->persist($book);
+            $entityManager->flush();
+        }
+
+        return $stored;
+    }
+}

--- a/tests/Integration/Controller/PurchaseControllerTest.php
+++ b/tests/Integration/Controller/PurchaseControllerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpYabs\Tests\Integration\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Money\Money;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PhpYabs\Controller\PurchaseController;
+use PhpYabs\Entity\Book;
+use PhpYabs\Entity\Purchase;
+use PhpYabs\Repository\BookRepository;
+use PhpYabs\ValueObject\ISBN;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+#[CoversClass(PurchaseController::class)]
+class PurchaseControllerTest extends WebTestCase
+{
+    public function testViewingHistoricalPurchaseDoesNotHijackCurrentCart(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $historicalId = $this->bakePurchaseWithBook($entityManager);
+        $entityManager->clear();
+
+        $currentId = $this->requestPurchaseId($client, '/purchases/current');
+        $this->assertNotSame($historicalId, $currentId);
+
+        $viewedId = $this->requestPurchaseId($client, "/purchases/$historicalId");
+        $this->assertSame($historicalId, $viewedId);
+
+        $this->assertSame($currentId, $this->requestPurchaseId($client, '/purchases/current'));
+    }
+
+    private function requestPurchaseId(KernelBrowser $client, string $uri): int
+    {
+        $crawler = $client->request('GET', $uri);
+        $this->assertResponseIsSuccessful();
+
+        $this->assertSame(1, preg_match('/\\d+/', $crawler->filter('h2')->text(), $matches));
+
+        return (int) $matches[0];
+    }
+
+    private function bakePurchaseWithBook(EntityManagerInterface $entityManager): int
+    {
+        $bookRepository = static::getContainer()->get(BookRepository::class);
+
+        $stored = (string) ISBN::fromString('123456789')->version13;
+        $book = $bookRepository->findOneBy(['isbn' => $stored]);
+        if (!$book) {
+            $book = new Book()
+                ->setIsbn('123456789')
+                ->setTitle('Test Book')
+                ->setAuthor('Test Author')
+                ->setPublisher('Test Publisher')
+                ->setPrice(Money::EUR(1000))
+            ;
+            $entityManager->persist($book);
+        }
+
+        $purchase = new Purchase();
+        $purchase->addBook($book);
+        $entityManager->persist($purchase);
+        $entityManager->flush();
+
+        return (int) $purchase->getId();
+    }
+}

--- a/tests/Integration/Repository/PurchaseRepositoryTest.php
+++ b/tests/Integration/Repository/PurchaseRepositoryTest.php
@@ -12,6 +12,7 @@ use PhpYabs\Entity\Book;
 use PhpYabs\Entity\Purchase;
 use PhpYabs\Repository\BookRepository;
 use PhpYabs\Repository\PurchaseRepository;
+use PhpYabs\ValueObject\ISBN;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 #[CoversClass(PurchaseRepository::class)]
@@ -74,9 +75,11 @@ class PurchaseRepositoryTest extends KernelTestCase
         return $purchase;
     }
 
-    private function bakeBook(string $isbn): ?Book
+    private function bakeBook(string $isbn): Book
     {
-        $book = $this->bookRepository->findOneBy(['isbn' => $isbn]);
+        // books are stored under their ISBN-13 form (see Book::convertISBNto13)
+        $stored = (string) ISBN::fromString($isbn)->version13;
+        $book = $this->bookRepository->findOneBy(['isbn' => $stored]);
         if (!$book) {
             $book = new Book()
                 ->setIsbn($isbn)

--- a/tests/Integration/Service/PurchaseServiceTest.php
+++ b/tests/Integration/Service/PurchaseServiceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpYabs\Tests\Integration\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Money\Money;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PhpYabs\Entity\Book;
+use PhpYabs\Repository\BookRepository;
+use PhpYabs\Repository\HitRepository;
+use PhpYabs\Repository\PurchaseRepository;
+use PhpYabs\Service\PurchaseService;
+use PhpYabs\ValueObject\ISBN;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[CoversClass(PurchaseService::class)]
+class PurchaseServiceTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private PurchaseRepository $purchaseRepository;
+    private BookRepository $bookRepository;
+    private HitRepository $hitRepository;
+
+    protected function setUp(): void
+    {
+        $container = self::getContainer();
+
+        $this->entityManager = $container->get(EntityManagerInterface::class);
+        $this->purchaseRepository = $container->get(PurchaseRepository::class);
+        $this->bookRepository = $container->get(BookRepository::class);
+        $this->hitRepository = $container->get(HitRepository::class);
+    }
+
+    public function testAddTwoBooksAndGetLines(): void
+    {
+        $isbn1 = $this->bakeBook('123456789');
+        $isbn2 = $this->bakeBook('316148410');
+        $this->entityManager->clear();
+
+        $service = $this->makeService();
+
+        $this->assertTrue($service->addBook($isbn1));
+        $this->assertTrue($service->addBook($isbn2));
+        $this->assertSame(2, $service->count());
+
+        // scanning the ISBN-10 printed on an older book must find the ISBN-13 stored one
+        $this->assertTrue($service->addBook((string) ISBN::fromString($isbn2)->version10));
+        $this->assertSame(2, $service->count());
+
+        $this->assertFalse($service->addBook('not-an-isbn'));
+
+        $lines = iterator_to_array($service->getLines(), false);
+
+        $this->assertCount(2, $lines);
+        $this->assertTrue(Money::EUR(1000)->equals($lines[0]->price));
+        $this->assertSame(1, $lines[0]->sequence);
+        $this->assertSame(2, $lines[1]->sequence);
+    }
+
+    private function makeService(): PurchaseService
+    {
+        return new PurchaseService(
+            $this->entityManager,
+            $this->purchaseRepository,
+            $this->bookRepository,
+            $this->hitRepository,
+        );
+    }
+
+    /**
+     * Returns the ISBN-13 under which the book is stored.
+     */
+    private function bakeBook(string $isbn): string
+    {
+        $stored = (string) ISBN::fromString($isbn)->version13;
+
+        if (!$this->bookRepository->findOneBy(['isbn' => $stored])) {
+            $book = new Book()
+                ->setIsbn($isbn)
+                ->setTitle('Test Book')
+                ->setAuthor('Test Author')
+                ->setPublisher('Test Publisher')
+                ->setPrice(Money::EUR(1000))
+            ;
+            $this->entityManager->persist($book);
+            $this->entityManager->flush();
+        }
+
+        return $stored;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the critical batch from a full-codebase bug hunt. Every fix was reproduced by a failing test first, then fixed.

### Bugs fixed

1. **`Purchase::addBook()` — TypeError on the second book.** The `findFirst()` predicate used a one-argument closure, but Doctrine invokes it as `($key, $element)`, so the typed `PurchaseLine` parameter received the integer collection key. Latent on an empty cart, fatal on every second scan. Now matches `removeBook()`'s correct signature.
2. **`PurchaseService::getLines()` called the nonexistent `Book::getPriceObject()`.** Rendering any non-empty cart was a fatal error. Now calls `getPrice()`.
3. **Viewing a historical purchase hijacked the current cart.** `PurchaseController` unconditionally wrote `purchase_id` to the session, so merely opening an old purchase from the archive list made it the "current" cart and new scans appended lines to it. The session is now only written for the `new`/`current` flows.
4. **Book delete-confirmation page 500'd.** `tabdel.html.twig` rendered `{{ book.price }}` on a `Money` object (no `__toString()`); now `{{ book.price | money_format }}`.
5. **Scanning any EAN-13 crashed on the `hits` table** (found by the new integration test): `PurchaseService::addBook()` stored the raw scan in the CHAR(9) `hits.ISBN` column ("Data too long" in strict-mode MariaDB) and compared raw scans against ISBN-13-stored books (so ISBN-10 scans of older books reported "not found"). Scans are now normalized through the `ISBN` value object; hits are keyed on the 9-digit core. Behavior change: unparseable scans return "not found" without being recorded as hits.
6. **`Book::$destinations` was never initialized** — added a constructor (surfaced by PHPStan once it could actually finish, see below).

### Test/tooling repairs

- **The integration suite could not run at all**: the container sets `APP_ENV=dev`, which PHPUnit's `<env>` does not override by default — all existing integration tests errored on `test.service_container`. Fixed with `force="true"` in `phpunit.dist.xml` plus the stale `App\Kernel` in `.env.test`.
- PHPStan crashed at its 128M memory limit before completing analysis; the Makefile target now passes `--memory-limit=512M`.
- Test-env `NullLogger` in `services.yaml` so WebTestCase runs aren't flagged risky (`failOnRisky` is on).
- `PurchaseRepositoryTest::bakeBook()` now looks books up by their stored ISBN-13 form, so repeated runs don't hit the unique constraint.

### New tests

- `tests/Entity/PurchaseTest.php` — add/remove/duplicate line behavior (unit)
- `tests/Integration/Service/PurchaseServiceTest.php` — end-to-end scan flow, ISBN-10/13 normalization, invalid scans
- `tests/Integration/Controller/PurchaseControllerTest.php` — session/current-cart isolation
- `tests/Integration/Controller/BookControllerTest.php` — delete-confirmation page renders

## Test plan

- `make phpunit`: 22 tests, 42 assertions, green
- `make phpstan`: no errors
- `make cs-fixer-dry`: clean
- Behat still fails 4/4 scenarios — verified identical failures on the unmodified tree (pre-existing: features assert Vue-rendered content the JS-less Mink driver can't see, plus a money-formatting mismatch), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
